### PR TITLE
docs: fix simple typo, queriery -> queries

### DIFF
--- a/model.py
+++ b/model.py
@@ -86,7 +86,7 @@ class Models(object):
 
     def search(self, search_type, value, total):
         """
-        search model for queriery
+        search model for queries
 
         args:
             serach_type: seach by tag, category, keyword, and or just main index of the blog


### PR DESCRIPTION
There is a small typo in model.py.

Should read `queries` rather than `queriery`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md